### PR TITLE
V0.1.10

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright © 2023 Geordi Filiotis
+Copyright © 2024 Geordi Filiotis
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geordi7/fint",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Strongly typed tools for typescript",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geordi7/fint",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Strongly typed tools for typescript",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@geordi7/fint",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Strongly typed tools for typescript",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && npx tsc",
-    "test": "npx tsc && npx mocha dist/tests/test.js"
+    "test": "npx tsc && npx mocha dist/tests/test.js",
+    "prepublishOnly": "npm run build && npm test"
   },
   "repository": {
     "type": "git",

--- a/src/event-tree.ts
+++ b/src/event-tree.ts
@@ -1,0 +1,149 @@
+
+import { flow } from "./pipes";
+import { iter, rec } from "./transforms";
+import { tuple } from "./types";
+
+export type EventTree<Msg, Ans> = {
+    subscribe: (path: string[], handler: Handler<Msg, Ans>) => Unsubscribe;
+    send: (path: string[], msg: Msg) => Responses<Ans>;
+    inspect: () => Readonly<Node<Msg,Ans>>;
+    iterResponses: (res: Responses<Ans>) => IterableIterator<[string[], Ans]>;
+}
+
+export type Handler<Msg, Ans> = (msg: Msg, toPath: string[], atPath: string[]) => Ans;
+export type Unsubscribe = () => void;
+export type Responses<Answer> = {
+    responses: Answer[],
+    childResponses: {[Step in string]: Responses<Answer>}
+};
+
+export type Node<Msg, Ans> = {
+    parent?: Node<Msg, Ans>,
+    name?: string,
+    handlers: Set<Handler<Msg, Ans>>,
+    children: {[Step in string]: Node<Msg, Ans>}
+};
+
+export type StrEventTree<Msg,Ans> = {
+    subscribe: (path: string, handler: StrHandler<Msg,Ans>) => Unsubscribe;
+    send: (path: string, msg: Msg) => Responses<Ans>;
+    inspect: () => Readonly<Node<Msg,Ans>>;
+    iterResponses: (res: Responses<Ans>) => IterableIterator<[string, Ans]>;
+}
+
+export type StrHandler<Msg, Ans> = (msg: Msg, toPath: string, atPath: string) => Ans;
+
+const newNode = <Msg, Ans>(parent?: Node<Msg, Ans>, name?: string) => ({parent, name, handlers: new Set(), children: {}}) as Node<Msg, Ans>;
+const newResponses = <A>(): Responses<A> => ({responses: [], childResponses: {}});
+
+export function createEventTree<Msg, Ans>(): EventTree<Msg, Ans> {
+    const root: Node<Msg, Ans> = newNode();
+
+    return {
+        subscribe(path, handler) {
+            let next = root;
+
+            for (const step of path) {
+                next = next.children[step] =
+                    next.children[step] ?? newNode(next, step);
+            }
+
+            next.handlers.add(handler);
+
+            return () => {
+                next.handlers.delete(handler);
+                while (
+                    next.handlers.size === 0 &&
+                    rec.k(next.children).length === 0
+                ) {
+                    const {name} = next;
+                    if (name) {
+                        next = next.parent!;
+                        delete next.children[name];
+                    } else {
+                        break;
+                    }
+                }
+            };
+        },
+
+        send(path, msg) {
+            // linecast
+            const results = newResponses<Ans>();
+            let collect = results;
+            let next = root;
+            let at = [] as string[];
+
+            for (const step of path) {
+                collect.responses = flow(next.handlers,
+                    iter.map(h => h(msg, path, [...at])),
+                    iter.collect);
+
+                if (step in next.children) {
+                    next = next.children[step];
+                    at.push(step)
+                    collect = collect.childResponses[step] = newResponses<Ans>();
+                } else {
+                    // the message was sent to a branch with no subscriptions
+                    // there is nothing more to be done
+                    return results;
+                }
+            }
+
+            // broadcast
+            Object.assign(collect, broadcast(path, at, next, msg));
+
+            return results;
+        },
+
+        iterResponses(res) {
+            return iterResponses([], res);
+        },
+
+        inspect() {
+            return root;
+        }
+    }
+}
+
+export function createPathEventTree<Msg,Ans>(pathSeparator: string): StrEventTree<Msg, Ans> {
+    const evt = createEventTree<Msg,Ans>();
+
+    const takePath = (p: string) => p.split(pathSeparator).filter(s => s.length > 0);
+    const makePath = (p: string[]) => p.join(pathSeparator);
+
+    return {
+        inspect() {return evt.inspect()},
+        subscribe(path, handler) {
+            return evt.subscribe(takePath(path), (m,to,at) =>
+                handler(m, makePath(to), makePath(at)));
+        },
+        send(path, msg) {
+            return evt.send(takePath(path), msg);
+        },
+        iterResponses(res) {
+            return flow(iterResponses([], res),
+                iter.map(([path, answer]) => tuple(makePath(path), answer))
+            );
+        }
+    }
+}
+
+function broadcast<M,A>(path: string[], at: string[], node: Node<M,A>, msg: M): Responses<A> {
+    return {
+        responses: flow(node.handlers,
+            iter.map(h => h(msg, path, at)),
+            iter.collect,
+        ),
+        childResponses: flow(node.children,
+            rec.map((child, name) => broadcast(path, [...at, name], child, msg))
+        ),
+    }
+}
+
+function * iterResponses<A>(path: string[], r: Responses<A>): IterableIterator<[string[], A]> {
+    yield * r.responses.map(a => tuple(path, a));
+    for (const [name, child] of rec.e(r.childResponses)) {
+        yield * iterResponses([...path, name], child);
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export * from './proxy';
 export * from './result';
 export * from './transforms';
 export * from './types';
+export * from './event-tree';

--- a/src/misc.ts
+++ b/src/misc.ts
@@ -2,19 +2,24 @@
 export const id = <T>(i: T) => i;
 export const identity = id;
 
+// equivalent to (s => {throw new Error(s)})('message')
 export function raise(msg: string): never {
     throw new Error(msg);
 }
 
+// if condition is false throw an error with the associated message
 export function assert(condition: boolean, ifFalse: string): void {
     condition ? null : raise(ifFalse);
 }
 
-export const memoize = <Args extends unknown[], Result>(fn: (...args: Args) => Result): (...args: Args) => Result => {
+// produce a memoized version of a function
+// the function should be pure
+// it will not be called more than once for a given input
+export const memoize = <Args extends unknown[], Output>(fn: (...args: Args) => Output): (...args: Args) => Output => {
     const memo = new Map();
     const ptr = Symbol('ptr');
     const err = Symbol('error');
-    return (...args: Args): Result => {
+    return (...args: Args): Output => {
         let place = memo;
         let hit = true;
         for (const arg of args) {
@@ -42,6 +47,8 @@ export const memoize = <Args extends unknown[], Result>(fn: (...args: Args) => R
 }
 
 // performance.now is the recommended timing function
+// usage:
+// const timedFn = timerFactory(performance.now)(fn);
 export const timerFactory = (timing: () => number) => <T>(fn: () => T): [T,number] => {
     const start = timing();
     const t = fn();

--- a/src/pipes.ts
+++ b/src/pipes.ts
@@ -18,6 +18,11 @@ export type Chain<T1> =
 // call it with no argument to extract the value
 export const chain = <T1>(i: T1): Chain<T1> =>
     (<T2>(op?: (i: T1) => T2) => op ? chain(op(i)) : i) as any;
+
+// flow builder
+// call with a value and a sequence of functions to apply
+// applies the first function to the value and each successive
+// function to the result of the previous one
 export const flow = ((u: unknown, ...fns: ((u: unknown) => unknown)[]): unknown => {
     for (const fn of fns) {
         u = fn(u);

--- a/src/result.ts
+++ b/src/result.ts
@@ -120,9 +120,9 @@ export class ResultOk<R0> implements IResult<R0,never> {
         return this.r;
     }
     ok(): R0 {return this.r;}
-    isOk(): true {return true;}
+    isOk(): this is ResultOk<R0> {return true;}
     err(): never {throw new Error(`Result is Ok but Err expected`);}
-    isErr(): false {return false;}
+    isErr(): this is ResultErr<never> {return false;}
     toString(): string {return `Ok(${String(this.r)})`;}
 }
 
@@ -156,9 +156,9 @@ export class ResultErr<E0> implements IResult<never,E0> {
         else
             throw new Error(String(this.e));
     }
-    isOk(): false {return false;}
+    isOk(): this is ResultOk<never> {return false;}
     err(): E0 {return this.e;}
-    isErr(): true {return true;}
+    isErr(): this is ResultErr<E0> {return true;}
     toString(): string {return `Err(${String(this.e)})`;}
 }
 

--- a/src/tests/test-event-tree.ts
+++ b/src/tests/test-event-tree.ts
@@ -1,0 +1,301 @@
+
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+
+import {createEventTree, createPathEventTree} from '../event-tree';
+
+export function test() {
+    describe('event-tree', () => {
+        it('sends messages to same-path targets', () => {
+            const etr = createEventTree<number,void>();
+            const collect = [] as number[];
+
+            etr.subscribe(['a'], n => {collect.push(n)});
+
+            etr.send(['a'], 1);
+
+            expect(collect).deep.equals([1]);
+        });
+
+        it('allows multiple handlers and specific handler removal', () => {
+            const etr = createEventTree<number,void>();
+            const collect = [] as number[];
+
+            const handler1 = (n: number) => {collect.push(10 + n)};
+            const handler2 = (n: number) => {collect.push(20 + n)};
+            const handler3 = (n: number) => {collect.push(30 + n)};
+            etr.subscribe([], handler1);
+            etr.subscribe([], handler2);
+            const unsub3 = etr.subscribe([], handler3);
+
+            etr.send([], 1);
+
+            unsub3();
+
+            etr.send([], 2);
+
+            expect(collect).deep.equals([11,21,31,12,22]);
+        });
+
+        it('sends messages to ancestors', () => {
+            const etr = createEventTree<number,void>();
+            const collect = [] as string[][];
+
+            const handler = (_: unknown,__: unknown, at: string[]) => {collect.push(at)};
+
+            etr.subscribe([], handler);
+            etr.subscribe(['a'], handler);
+            etr.subscribe(['a', 'b'], handler);
+            etr.subscribe(['a', 'b', 'c'], handler);
+            etr.subscribe(['a', 'b', 'c', 'd'], handler);
+
+            etr.send(['a','b','c','d'], 1);
+
+            expect(collect).deep.equals([
+                [],
+                ['a'],
+                ['a','b'],
+                ['a','b','c'],
+                ['a','b','c','d'],
+            ]);
+        });
+
+        it('broadcasts messages to all decendants', () => {
+            const etr = createEventTree<number,void>();
+            const collect = [] as string[][];
+
+            const handler = (_: unknown,__: unknown, at: string[]) => {collect.push(at)};
+
+            etr.subscribe(['a', 'aa', 'aaa'], handler);
+            etr.subscribe(['a', 'aa', 'aab'], handler);
+            etr.subscribe(['a', 'ab', 'aba'], handler);
+            etr.subscribe(['a', 'ab', 'abb'], handler);
+
+            etr.send(['a'], 1);
+
+            expect(collect).deep.equals([
+                ['a', 'aa', 'aaa'],
+                ['a', 'aa', 'aab'],
+                ['a', 'ab', 'aba'],
+                ['a', 'ab', 'abb']
+            ]);
+        });
+
+        it('does not send to other branches', () => {
+            const etr = createEventTree<number,void>();
+            const collect = [] as string[][];
+
+            const handler = (_: unknown,__: unknown, at: string[]) => {collect.push(at)};
+
+            etr.subscribe(['a', 'aa'], handler);
+            etr.subscribe(['a', 'ab'], handler);
+            etr.subscribe(['b', 'ba'], handler);
+            etr.subscribe(['b', 'bb'], handler);
+
+            etr.send(['a'], 1);
+
+            expect(collect).deep.equals([
+                ['a', 'aa'],
+                ['a', 'ab'],
+            ]);
+        });
+
+        it('cleans up the tree after unsubscribe', () => {
+            const etr = createEventTree<number,void>();
+            const collect = [] as string[][];
+
+            const handler = (_: unknown,__: unknown, at: string[]) => {collect.push(at)};
+
+            const unsub = etr.subscribe(['a', 'b', 'c', 'd'], handler);
+
+            etr.send(['a'], 1);
+            expect(collect).deep.equals([['a', 'b', 'c', 'd']]);
+
+            unsub();
+
+            expect(etr.inspect()).deep.equals({
+                parent: undefined,
+                name: undefined,
+                handlers: new Set(),
+                children: {},
+            });
+        });
+
+        it('includes an iterResponses methid which enumerates all responses with their corresponding paths', () => {
+            const etr = createEventTree<number,number>();
+
+            etr.subscribe([], n => n);
+            etr.subscribe(['a'], n => n);
+            etr.subscribe(['a','aa'], n => n);
+            etr.subscribe(['a','ab'], n => n);
+            etr.subscribe(['a','aa','aaa'], n => n);
+
+            const collect = [...etr.iterResponses(etr.send(['a'], 1))]
+
+            expect(collect).deep.equals([
+                [[], 1],
+                [['a'], 1],
+                [['a','aa'], 1],
+                [['a','aa','aaa'], 1],
+                [['a','ab'], 1],
+            ]);
+        })
+
+        describe('path-event-tree', () => {
+            it('sends messages to same-path targets', () => {
+                const etr = createPathEventTree<number,void>('/');
+                const collect = [] as number[];
+    
+                etr.subscribe('a', n => {collect.push(n)});
+    
+                etr.send('a', 1);
+    
+                expect(collect).deep.equals([1]);
+            });
+
+            it('allows multiple handlers and specific handler removal', () => {
+                const etr = createPathEventTree<number,void>('/');
+                const collect = [] as number[];
+
+                const handler1 = (n: number) => {collect.push(10 + n)};
+                const handler2 = (n: number) => {collect.push(20 + n)};
+                const handler3 = (n: number) => {collect.push(30 + n)};
+                etr.subscribe('', handler1);
+                etr.subscribe('', handler2);
+                const unsub3 = etr.subscribe('', handler3);
+
+                etr.send('', 1);
+
+                unsub3();
+
+                etr.send('', 2);
+
+                expect(collect).deep.equals([11,21,31,12,22]);
+            });
+    
+            it('sends messages to ancestors', () => {
+                const etr = createPathEventTree<number,void>('/');
+                const collect = [] as string[];
+    
+                const handler = (_: unknown, __: unknown, at: string) => {collect.push(at)};
+    
+                etr.subscribe('', handler);
+                etr.subscribe('a', handler);
+                etr.subscribe('a/b', handler);
+                etr.subscribe('a/b/c', handler);
+                etr.subscribe('a/b/c/d', handler);
+    
+                etr.send('a/b/c/d', 1);
+    
+                expect(collect).deep.equals([
+                    '',
+                    'a',
+                    'a/b',
+                    'a/b/c',
+                    'a/b/c/d',
+                ]);
+            });
+    
+            it('broadcasts messages to all decendants', () => {
+                const etr = createPathEventTree<number,void>('/');
+                const collect = [] as string[];
+    
+                const handler = (_: unknown,__: unknown, at: string) => {collect.push(at)};
+    
+                etr.subscribe('a/aa/aaa', handler);
+                etr.subscribe('a/aa/aab', handler);
+                etr.subscribe('a/ab/aba', handler);
+                etr.subscribe('a/ab/abb', handler);
+    
+                etr.send('a', 1);
+    
+                expect(collect).deep.equals([
+                    'a/aa/aaa',
+                    'a/aa/aab',
+                    'a/ab/aba',
+                    'a/ab/abb',
+                ]);
+            });
+    
+            it('does not send to other branches', () => {
+                const etr = createPathEventTree<number,void>('/');
+                const collect = [] as string[];
+    
+                const handler = (_: unknown,__: unknown, at: string) => {collect.push(at)};
+    
+                etr.subscribe('a/aa', handler);
+                etr.subscribe('a/ab', handler);
+                etr.subscribe('b/ba', handler);
+                etr.subscribe('b/bb', handler);
+    
+                etr.send('a', 1);
+    
+                expect(collect).deep.equals([
+                    'a/aa',
+                    'a/ab',
+                ]);
+            });
+
+            it('cleans up the tree after unsubscribe', () => {
+                const etr = createPathEventTree<number,void>('/');
+                const collect = [] as string[];
+    
+                const handler = (_: unknown,__: unknown, at: string) => {collect.push(at)};
+    
+                const unsub = etr.subscribe('a/b/c/d', handler);
+    
+                etr.send('a', 1);
+                expect(collect).deep.equals(['a/b/c/d']);
+    
+                unsub();
+    
+                expect(etr.inspect()).deep.equals({
+                    parent: undefined,
+                    name: undefined,
+                    handlers: new Set(),
+                    children: {},
+                });
+            });
+
+            it('includes an iterResponses method which enumerates all responses and wraps the paths', () => {
+                const etr = createPathEventTree<number,number>('/');
+    
+                etr.subscribe('', n => n);
+                etr.subscribe('a', n => n);
+                etr.subscribe('a/aa', n => n);
+                etr.subscribe('a/ab', n => n);
+                etr.subscribe('a/aa/aaa', n => n);
+
+                const collect = [...etr.iterResponses(etr.send('a', 1))]
+
+                expect(collect).deep.equals([
+                    ['', 1],
+                    ['a', 1],
+                    ['a/aa', 1],
+                    ['a/aa/aaa', 1],
+                    ['a/ab', 1],
+                ]);
+            });
+        })
+    });
+}
+
+// original test case
+if(0) {
+    const etr = createEventTree<number, number>();
+    
+    const mh = (label:string) => (m: number, p: string[], mp: string[]) => {
+        console.log(label, p, mp, m);
+        return m;
+    }
+    
+    etr.subscribe([], mh('root'));
+    etr.subscribe(['one'], mh('one'));
+    etr.subscribe(['one','two'], mh('one-two'));
+    etr.subscribe(['one','three'], mh('one-three'));
+    etr.subscribe(['one','three','five'], mh('one-three-five'));
+    etr.subscribe(['one','four'], mh('one-four'));
+    etr.subscribe(['else'], mh('else'));
+    
+    console.log('received', [...etr.iterResponses(etr.send(['one', 'three'], 1))]);
+}

--- a/src/tests/test-proxy.ts
+++ b/src/tests/test-proxy.ts
@@ -1,0 +1,56 @@
+
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+
+import {
+    readProxy, pathFunctionProxy
+} from '../proxy';
+
+// readProxy type verification
+((): {[K in string]: (n: number) => boolean} => readProxy(_ => (n: number) => n > 4));
+
+// pathFunctionProxy type verification
+((): (() => string) => pathFunctionProxy(p => () => p.join()));
+((): (() => string) => pathFunctionProxy(p => () => p.join()).x.y.z);
+((): ((a: string, b: number, c: boolean) => string) =>
+    pathFunctionProxy(p => (a: string, b: number, c: boolean) => p.join() + a + `${b}${c}`));
+((): ((a: string, b: number, c: boolean) => string) =>
+    pathFunctionProxy(p => (a: string, b: number, c: boolean) => p.join() + a + `${b}${c}`).x.y.z);
+
+
+export function test() {
+    describe('proxy', () => {
+        describe('readProxy', () => {
+            it('converts properties to string arguments', () => {
+                const rp = readProxy(s => s);
+
+                expect(rp.a).equals('a');
+                expect(rp.b).not.equals('a');
+            });
+        });
+
+        describe('pathFunctionProxy', () => {
+            it('is callable at the root', () => {
+                const pfp = pathFunctionProxy(p => () => p);
+
+                expect(pfp()).deep.equals([]);
+            });
+
+            it('reproduces deep properties as a path of strings', () => {
+                const pfp = pathFunctionProxy(p => () => p);
+
+                expect(pfp.a()).deep.equals(['a']);
+                expect(pfp.x.y.z()).deep.equals(['x','y','z']);
+            });
+
+            it('passes through arguments sensibly', () => {
+                const pfp = pathFunctionProxy(p => (...a: number[]) => [p,a]);
+
+                expect(pfp(1,2,3)).deep.equals([[],[1,2,3]]);
+                expect(pfp.x.y.z(99)).deep.equals([['x','y','z'],[99]]);
+            });
+        })
+    });
+}
+
+

--- a/src/tests/test-result.ts
+++ b/src/tests/test-result.ts
@@ -1,5 +1,6 @@
 import { Result } from "../result";
 
+// type verifications for lift and capture
 (): Result<number, Error> => Result.lift((n: number) => n+1)(1);
 (): Result<number, Error> => Result.capture(() => 1);
 (): Promise<Result<number, Error>> => Result.lift(async (n: number) => n+1)(1);

--- a/src/tests/test.ts
+++ b/src/tests/test.ts
@@ -10,3 +10,6 @@ transforms.test();
 
 import * as types from './test-types';
 types.test();
+
+import * as proxy from './test-proxy';
+proxy.test();

--- a/src/tests/test.ts
+++ b/src/tests/test.ts
@@ -13,3 +13,6 @@ types.test();
 
 import * as proxy from './test-proxy';
 proxy.test();
+
+import * as eventTree from './test-event-tree';
+eventTree.test();

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,15 @@ export const is = {
     date: (thing: unknown): thing is Date => (thing instanceof Date && Number.isFinite(thing.valueOf())),
 }
 
+// exhaust(value, message) - type utility function
+//  when resolving a union, the left over value after all possiblities have been exhausted should have type never
+//  pass the variable into this function, with relevant message for the resulting error
+//  typescript will guard against calling this function on a non-never value
+//  and if at runtime an unexpected value arrives it will turn into a runtime error
+export function exhaust(_: never, msg: string): never {
+    throw new Error(msg);
+}
+
 // nominal types
 declare const brand: unique symbol;
 export type Nominal<T, Label extends string> = T & {readonly [brand]: Label};
@@ -55,6 +64,11 @@ export const makeJSONSerializable = (pod: PlainOldData): JSONSerializable => flo
 export type KeysAcrossUnion<T> = T extends infer TT ? string & keyof TT : never;
 
 export type PropsAcrossUnion<T> = T extends infer TT ? TT[keyof TT] : never;
+
+export type RequiredKeys<T> =
+    keyof T extends infer K ? K extends keyof T ?
+        undefined extends T[K] ? never : K : never : never
+;
 
 export type Tuple<A extends unknown[]> =
     A extends [] ? [] :

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-      "lib": ["esnext"],
       "target": "esnext",
       "module": "commonjs",
       "moduleResolution": "node",


### PR DESCRIPTION
A few fixes

Added a new Proxy that allows the user to chain property accesses together and deliver those strings to a callable:

```typescript
const p = pathFunctionProxy((path: string[]) => console.log(path));

p(); // []
p.a.b.c(); // ['a','b','c']
```

Exported neverProxyHandler which lets you create invalid proxies to extend.

Added labelled variants to proxies.

Added exhaust() for verifying that union types are exhausted in match-like logic.

Added EventTree and PathEventTree and constructors:

event trees allow hierarchical subscription and broadcast of events along with the collection and iteration of result sets.
see the tests for details and examples